### PR TITLE
Bugfix: weighing dayside/nightside integrated temperature by emitted power

### DIFF
--- a/kelp/core.py
+++ b/kelp/core.py
@@ -589,7 +589,13 @@ class Model(object):
 
     def integrated_temperatures(self, n_theta=100, n_phi=100, f=2 ** -0.5):
         """
-        Temperature map as a function of latitude (theta) and longitude (phi).
+        Compute the integrated dayside and nightside temperatures for the
+        temperature map.
+
+        .. note::
+            The dayside/nightside integrated temperatures reported by this
+            function are weighted by their emitted power, i.e. we take the
+            1/4 root of the mean of the temperature raised to the fourth power.
 
         Parameters
         ----------
@@ -628,12 +634,12 @@ class Model(object):
         ).T
 
         dayside_integrated_temperature = np.average(
-            T[:, dayside_hemisphere],
+            T[:, dayside_hemisphere] ** 4,
             weights=integrand_dayside[:, dayside_hemisphere]
-        )
+        ) ** (1/4)
         nightside_integrated_temperature = np.average(
-            T[:, nightside_hemisphere],
+            T[:, nightside_hemisphere] ** 4,
             weights=integrand_nightside[:, nightside_hemisphere]
-        )
+        ) ** (1/4)
 
         return dayside_integrated_temperature, nightside_integrated_temperature

--- a/kelp/tests/test_core.py
+++ b/kelp/tests/test_core.py
@@ -86,7 +86,7 @@ def test_argmin(y, x):
 def test_integrated_temperatures():
 
     # These parameters have been chi-by-eye "fit" to the Spitzer/3.6 um PC
-    f = 0.68
+    f = 0.67
 
     C_ml = [[0],
             [0, 0.18, 0]]

--- a/kelp/theano/theano.py
+++ b/kelp/theano/theano.py
@@ -270,7 +270,6 @@ def thermal_phase_curve(xi, hotspot_offset, omega_drag,
     filt_transmittance_tt = broadcaster()
     filt_transmittance_tt = filt_transmittance[None, None, None, :]
 
-    # Cython alternative to the pure python implementation:
     h_ml_sum = h_ml_sum_theano(hotspot_offset, omega_drag,
                                alpha, theta2d_tt, phi2d_tt, C_11)
     T_eq = f * T_s * tt.pow(a_rs, -half)
@@ -384,6 +383,8 @@ def reflected_phase_curve(phases, omega, g, a_rp):
         units of ppm.
     A_g : tensor-like
         Geometric albedo derived for the planet given {omega, g}.
+    q : tensor-like
+        Integral phase function
     """
     # Convert orbital phase on (0, 1) to "alpha" on (0, np.pi)
     alpha = (2 * np.pi * phases - np.pi).astype(floatX)


### PR DESCRIPTION
In the current version of kelp, we're taking the day/night side integrated temperature by doing the average of the temperature map on the day/night side, weighed by the visibility of each surface element. What we actually observe is the power emitted which scales as T^4. This PR tweaks the `Model.integrated_temperatures` function to return `(mean(T^4))^(1/4)`. 

This required a slight tweak to the test against Knutson's dayside and Keating's nightside temperatures, in which I improve the (manually tuned) "fit" considerably by tweaking `f`. Both temperatures are still consistent within 1-sigma.

Big thanks to @KathrynJones1 for thinking this through with me.