### PR TITLE
Fixing case where abs(xi)==pi in cython

### DIFF
--- a/kelp/core.py
+++ b/kelp/core.py
@@ -70,8 +70,7 @@ def H(l, theta, alpha):
                 tilda_mu(theta, alpha) ** 2 + 12)
     elif l == 5:
         return (32 * tilda_mu(theta, alpha) ** 5 - 160 *
-                tilda_mu(theta, alpha) ** 3 + 120 * 
-                tilda_mu(theta, alpha))
+                tilda_mu(theta, alpha) ** 3 + 120)
     elif l == 6:
         return (64 * tilda_mu(theta, alpha) ** 6 - 480 *
                 tilda_mu(theta, alpha) ** 4 + 720 *

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ deps =
     scipy
     matplotlib
     jax
+    jaxlib
+    arviz==0.11.0
 
 # Configure deps installed via conda
 conda_deps=


### PR DESCRIPTION
This implements the fix suggested in #27 by @delinea for the Cython implementation, where there are nonsense values returned by Equation 11 of HMK 2021 when the planet is exactly between the observer and the star.

Fixes #27.