### PR TITLE
Compatibility with newer JAX and numpy versions

### DIFF
--- a/kelp/jax/jax.py
+++ b/kelp/jax/jax.py
@@ -1,8 +1,13 @@
 import numpy as np
 from numpy import pi as pi64
 from jax import numpy as jnp
-from jax.config import config
-config.update('jax_enable_x64', True)
+#from jax.config import config          # I think this way of enabling 64-bit precision in deprecated in jax
+#config.update('jax_enable_x64', True)
+# New way of enabling 64-bit precision (from jaxoplanet tutorial example)
+import jax
+jax.config.update(
+    "jax_enable_x64", True
+)  # For 64-bit precision since JAX defaults to 32-bit
 
 __all__ = [
     'thermal_phase_curve',


### PR DESCRIPTION
Hi @bmorris3,

The current version of `kelp` will not work with newer JAX versions since there is a new way to enable 64-bit precision. Similarly, it will also not work with numpy 2. The main issue with numpy is that `np.cast` was removed in numpy 2. The error message suggests using `np.asarray` instead. I addressed both of these issues in this PR. 

I have tried this version on my computer, and my version is working well with numpy v2.1.3 and JAX v0.8.1. Please let me know if you have any questions or comments on this.

Cheers,
Jayshil